### PR TITLE
HTTP/2 Transport Tuning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,3 +5,5 @@ go 1.22
 require github.com/things-go/go-socks5 v0.1.1
 
 require golang.org/x/net v0.35.0
+
+require golang.org/x/text v0.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,5 +8,7 @@ github.com/things-go/go-socks5 v0.1.1 h1:48hy9cHEXPKeG91G/g4n8zW4uynzPUQy/FkcrJ7
 github.com/things-go/go-socks5 v0.1.1/go.mod h1:1YBHVYG7Oli5ae+Pwkp630cPAwY1pjUPmohO1n0Emg0=
 golang.org/x/net v0.35.0 h1:T5GQRQb2y08kTAByq9L4/bz8cipCdA8FbRTXewonqY8=
 golang.org/x/net v0.35.0/go.mod h1:EglIi67kWsHKlRzzVMUD93VMSWGFOMSZgxFjparz1Qk=
+golang.org/x/text v0.22.0 h1:bofq7m3/HAFvbF51jz3Q9wLg3jkvSPuiZu/pD1XwgtM=
+golang.org/x/text v0.22.0/go.mod h1:YRoo4H8PVmsu+E3Ou7cqLVH8oXWIHVoX0jqUWALQhfY=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/carrier/fronting.go
+++ b/internal/carrier/fronting.go
@@ -15,6 +15,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"golang.org/x/net/http2"
 )
 
 const frontedProbeOKBody = "GooseRelay forwarder OK"
@@ -362,6 +364,23 @@ func newFrontedClient(googleIP, sniHost string, pollTimeout time.Duration, sessi
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   15 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
+	}
+
+	// Configure HTTP/2 so the long-lived h2 connection sends pings and detects
+	// black-holed peers quickly. Without ReadIdleTimeout, a dead h2 conn can
+	// linger until the kernel's TCP keepalive fires (~2 hours by default),
+	// leaking poll worker time as in-flight requests stall.
+	if h2t, err := http2.ConfigureTransports(transport); err == nil && h2t != nil {
+		h2t.ReadIdleTimeout = 30 * time.Second
+		h2t.PingTimeout = 15 * time.Second
+		// Raise the max DATA frame size we are willing to receive from 16 KiB
+		// (spec default) to 1 MiB. Each DATA frame carries a 9-byte header,
+		// so on a long bulk download (Apps Script gateway streaming a video
+		// chunk back) the framing overhead drops by ~64× and the receiver
+		// makes ~64× fewer Read syscalls per MiB. Stream/conn flow control
+		// windows in golang.org/x/net/http2 already default to 4 MiB / 1 GiB,
+		// so the actual throughput cap is RTT-bound, not window-bound.
+		h2t.MaxReadFrameSize = 1 << 20
 	}
 
 	return &http.Client{Transport: transport, Timeout: pollTimeout}


### PR DESCRIPTION
Implemented HTTP/2 transport tuning in the fronting client to improve throughput and connection reliability. Specifically, it increases the MaxReadFrameSize to 1 MiB to reduce framing overhead for bulk downloads and adds ReadIdleTimeout/PingTimeout to proactively detect and close dead connections. Originally found in [easyfast2008's fork](https://github.com/easyfast2008/GooseRelayVPN) but split and adapted to the latest main branch.