### PR TITLE
SOCKS TCP_NODELAY & QUICKACK

### DIFF
--- a/internal/socks/quickack_linux.go
+++ b/internal/socks/quickack_linux.go
@@ -1,0 +1,35 @@
+//go:build linux
+
+package socks
+
+import (
+	"net"
+	"syscall"
+)
+
+// setQuickAck disables Linux's TCP delayed-ACK behavior on c. Without this,
+// the kernel can hold back an ACK for up to 40 ms hoping to piggyback it on
+// a forthcoming data segment — fine for bulk traffic but adds visible latency
+// to small request/reply pairs (DNS-over-HTTPS, REST GETs, TLS handshakes).
+//
+// TCP_QUICKACK is a one-shot hint that the kernel resets after subsequent
+// segments, so we re-apply it on each accept; the meaningful window is the
+// first few RTTs of every connection, which is exactly when small interactive
+// payloads dominate.
+//
+// No-ops cleanly on connections that aren't *net.TCPConn or where the
+// SyscallConn / Setsockopt calls fail (CAP_NET_RAW restricted, kernel
+// without TCP_QUICKACK, etc.).
+func setQuickAck(c net.Conn) {
+	tcp, ok := c.(*net.TCPConn)
+	if !ok {
+		return
+	}
+	raw, err := tcp.SyscallConn()
+	if err != nil {
+		return
+	}
+	_ = raw.Control(func(fd uintptr) {
+		_ = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_QUICKACK, 1)
+	})
+}

--- a/internal/socks/quickack_other.go
+++ b/internal/socks/quickack_other.go
@@ -1,0 +1,10 @@
+//go:build !linux
+
+package socks
+
+import "net"
+
+// setQuickAck is a no-op on non-Linux platforms. TCP_QUICKACK is a Linux-only
+// socket option; macOS/BSD lack the equivalent toggle, and Windows handles
+// delayed-ACK via a registry-tunable global default rather than per-socket.
+func setQuickAck(_ net.Conn) {}

--- a/internal/socks/server.go
+++ b/internal/socks/server.go
@@ -21,6 +21,12 @@ type SessionFactory func(target string) *session.Session
 // a VirtualConn over a fresh tunneled session. The DNS resolver is overridden
 // with a no-op to prevent local DNS leaks (clients must use socks5h://).
 //
+// Wraps the listener with a TCP_NODELAY + TCP_QUICKACK applying acceptor so
+// the kernel doesn't introduce 40 ms Nagle delays on small SOCKS payloads
+// (HTTP request lines, TLS handshake records) and doesn't hold back ACKs for
+// up to 40 ms on small request/reply pairs. The exit side already disables
+// Nagle for upstream connections; mirroring on the local side closes the loop.
+//
 // When user and pass are both non-empty, RFC 1929 username/password
 // authentication is required; unauthenticated clients are rejected.
 //
@@ -47,8 +53,35 @@ func Serve(_ context.Context, listenAddr, user, pass string, factory SessionFact
 			},
 		}))
 	}
+
+	ln, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		return err
+	}
 	server := socks5.NewServer(opts...)
-	return server.ListenAndServe("tcp", listenAddr)
+	return server.Serve(&noDelayListener{Listener: ln})
+}
+
+// noDelayListener wraps net.Listener so each accepted *net.TCPConn has both
+// SetNoDelay(true) and (on Linux) TCP_QUICKACK applied. This eliminates the
+// kernel's 40 ms Nagle delay on small SOCKS write payloads and the 40 ms
+// delayed-ACK on small read replies — together they cover both directions
+// of every interactive request/reply pair (DNS-over-HTTPS, REST GETs, TLS
+// handshake records).
+type noDelayListener struct {
+	net.Listener
+}
+
+func (l *noDelayListener) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	if tcp, ok := c.(*net.TCPConn); ok {
+		_ = tcp.SetNoDelay(true)
+	}
+	setQuickAck(c)
+	return c, nil
 }
 
 // noopResolver is a SOCKS5 name resolver that returns the host string verbatim


### PR DESCRIPTION
Optimized the local SOCKS listener by disabling Nagle's algorithm (TCP_NODELAY) and Linux delayed ACKs (TCP_QUICKACK). This ensures that small interactive payloads, such as TLS handshake records and HTTP request lines, are transmitted and acknowledged immediately, significantly improving responsiveness for web browsing and interactive applications. Originally found in [easyfast2008's fork](https://github.com/easyfast2008/GooseRelayVPN) but split and adapted to the latest main branch.