### PR TITLE
Buffer Pooling (sync.Pool)

### DIFF
--- a/internal/exit/exit.go
+++ b/internal/exit/exit.go
@@ -144,6 +144,10 @@ type Server struct {
 	// otherwise return empty and burn through HTTP requests.
 	activity map[[frame.ClientIDLen]byte]chan struct{}
 	stats    serverStats
+
+	// upstreamReadPool is a sync.Pool of upstreamReadBuf (256KiB) buffers
+	// reused across upstream pump goroutines.
+	upstreamReadPool sync.Pool
 }
 
 // serverStats holds atomic counters surfaced periodically by runStatsLoop.
@@ -168,7 +172,7 @@ func New(cfg Config) (*Server, error) {
 		return nil, err
 	}
 	dialFn := dialFunc(cfg.UpstreamProxy)
-	return &Server{
+	s := &Server{
 		cfg:           cfg,
 		aead:          aead,
 		dial:          dialFn,
@@ -183,7 +187,12 @@ func New(cfg Config) (*Server, error) {
 		dialFail:      make(map[string]time.Time),
 		pendingRSTs:   make(map[[frame.ClientIDLen]byte][]*frame.Frame),
 		activity:      make(map[[frame.ClientIDLen]byte]chan struct{}),
-	}, nil
+	}
+	s.upstreamReadPool.New = func() interface{} {
+		buf := make([]byte, upstreamReadBuf)
+		return &buf
+	}
+	return s, nil
 }
 
 // dialFunc returns a dial function. When proxyAddr is non-empty it routes all
@@ -531,7 +540,14 @@ func (s *Server) openSession(id [frame.SessionIDLen]byte, target string, owner [
 	// Upstream → session.EnqueueTx (downstream direction).
 	go func() {
 		defer upstream.Close()
-		buf := make([]byte, upstreamReadBuf)
+		bufP := s.upstreamReadPool.Get().(*[]byte)
+		buf := *bufP
+		defer func() {
+			// Zero the pointer so we don't accidentally hold a reference;
+			// the pool returns the slice header so future Reads get a fresh
+			// buffer view but back the same allocation.
+			s.upstreamReadPool.Put(bufP)
+		}()
 		firstRead := true
 		for {
 			n, err := upstream.Read(buf)

--- a/internal/frame/crypto.go
+++ b/internal/frame/crypto.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"sync"
 )
 
 // Crypto wraps an AES-256-GCM AEAD with the relay-tunnel envelope format:
@@ -75,6 +76,21 @@ func (c *Crypto) Open(envelope []byte) ([]byte, error) {
 // are never delivered to a different client polling the same server.
 const ClientIDLen = 16
 
+// batchPool reuses the marshaled-slice scratch and the plaintext header
+// buffer across EncodeBatch calls. Without pooling, each batch allocates two
+// fresh buffers (the plain header + the marshaled-frame slice header), which
+// is meaningful at our drain rate (≤ every 350 ms per worker, 3 workers).
+var (
+	encPlainPool = sync.Pool{New: func() interface{} {
+		buf := make([]byte, 0, 64*1024)
+		return &buf
+	}}
+	encMarshaledPool = sync.Pool{New: func() interface{} {
+		buf := make([][]byte, 0, 32)
+		return &buf
+	}}
+)
+
 // EncodeBatch packs zero or more frames into a base64-encoded HTTP body.
 //
 // Wire format (before base64):
@@ -99,18 +115,41 @@ func EncodeBatch(c *Crypto, clientID [ClientIDLen]byte, frames []*Frame) ([]byte
 	}
 
 	// Marshal all frames first so we know the exact plaintext size.
-	marshaled := make([][]byte, len(frames))
+	marshaledP := encMarshaledPool.Get().(*[][]byte)
+	marshaled := (*marshaledP)[:0]
+	defer func() {
+		for i := range marshaled {
+			marshaled[i] = nil
+		}
+		marshaled = marshaled[:0]
+		*marshaledP = marshaled
+		encMarshaledPool.Put(marshaledP)
+	}()
+
 	plainSize := ClientIDLen + 2 // client_id + u16 frame count
-	for i, f := range frames {
+	for _, f := range frames {
 		raw, err := f.Marshal()
 		if err != nil {
 			return nil, fmt.Errorf("batch: marshal frame: %w", err)
 		}
-		marshaled[i] = raw
+		marshaled = append(marshaled, raw)
 		plainSize += 4 + len(raw) // u32 length prefix + frame bytes
 	}
 
-	plain := make([]byte, 0, plainSize)
+	// Pull a plaintext scratch buffer from the pool; grow if needed.
+	plainP := encPlainPool.Get().(*[]byte)
+	plain := (*plainP)[:0]
+	if cap(plain) < plainSize {
+		plain = make([]byte, 0, plainSize)
+	}
+	defer func() {
+		// Reset and return to pool. The capacity is preserved so the next
+		// EncodeBatch reuses the same underlying allocation.
+		plain = plain[:0]
+		*plainP = plain
+		encPlainPool.Put(plainP)
+	}()
+
 	plain = append(plain, clientID[:]...)
 	plain = append(plain, byte(len(frames)>>8), byte(len(frames)))
 	for _, raw := range marshaled {


### PR DESCRIPTION
Introduced memory pooling for the most allocation-heavy parts of the VPN. Large 256KiB buffers used for reading from upstream targets and the intermediate buffers used for framing batches are now reused via `sync.Pool`. This significantly reduces the frequency of garbage collection and prevents memory spikes during sustained high-speed transfers. Originally found in [easyfast2008's fork](https://github.com/easyfast2008/GooseRelayVPN) but split and adapted to the latest main branch.