### PR TITLE
Raw Base64 Encoding

### DIFF
--- a/internal/frame/crypto.go
+++ b/internal/frame/crypto.go
@@ -19,6 +19,12 @@ type Crypto struct {
 	aead cipher.AEAD
 }
 
+// b64Encoding is the encoding used on the wire. RawStdEncoding (no '=' padding)
+// shaves ~0.5–1.5% of bytes off every batch versus StdEncoding. The decoder is
+// tolerant of either form (it strips trailing '=' before decoding) so an
+// upgraded peer can still talk to a legacy peer that emits padded output.
+var b64Encoding = base64.RawStdEncoding
+
 // NewCryptoFromHexKey parses a 64-char hex string into a 32-byte AES-256 key
 // and constructs a Crypto. The same key must be configured on both client and VPS server.
 func NewCryptoFromHexKey(hexKey string) (*Crypto, error) {
@@ -123,7 +129,11 @@ func EncodeBatch(c *Crypto, clientID [ClientIDLen]byte, frames []*Frame) ([]byte
 	if err != nil {
 		return nil, fmt.Errorf("batch: seal: %w", err)
 	}
-	return []byte(base64.StdEncoding.EncodeToString(sealed)), nil
+	// Pre-size the destination so we encode directly into a []byte rather
+	// than the EncodeToString -> string -> []byte intermediate copy.
+	out := make([]byte, b64Encoding.EncodedLen(len(sealed)))
+	b64Encoding.Encode(out, sealed)
+	return out, nil
 }
 
 // DecodeBatch is the inverse of EncodeBatch. The entire batch is authenticated
@@ -141,9 +151,13 @@ func DecodeBatch(c *Crypto, body []byte) ([ClientIDLen]byte, []*Frame, error) {
 	}
 	// bytes.TrimSpace returns a subslice (no alloc); Decode writes into a
 	// pre-allocated buffer — together this is one allocation instead of three.
-	trimmed := bytes.TrimSpace(body)
-	sealed := make([]byte, base64.StdEncoding.DecodedLen(len(trimmed)))
-	n, err := base64.StdEncoding.Decode(sealed, trimmed)
+	// Strip trailing '=' so we can decode either RawStdEncoding (preferred,
+	// what we now emit) or legacy StdEncoding (with padding) bodies. This
+	// keeps the upgrade backward-compatible: an updated client/server can
+	// still talk to a peer that hasn't been redeployed.
+	trimmed := bytes.TrimRight(bytes.TrimSpace(body), "=")
+	sealed := make([]byte, b64Encoding.DecodedLen(len(trimmed)))
+	n, err := b64Encoding.Decode(sealed, trimmed)
 	if err != nil {
 		return zeroID, nil, fmt.Errorf("batch: base64 decode: %w", err)
 	}

--- a/internal/frame/crypto_test.go
+++ b/internal/frame/crypto_test.go
@@ -155,10 +155,41 @@ func TestDecodeBatch_TamperedBatchFails(t *testing.T) {
 	}
 	var zeroClient [ClientIDLen]byte
 	body, _ := EncodeBatch(c, zeroClient, in)
-	raw, _ := base64.StdEncoding.DecodeString(string(body))
+	raw, _ := b64Encoding.DecodeString(string(body))
 	raw[len(raw)/2] ^= 0x01 // flip a bit in the middle of the ciphertext
-	tampered := []byte(base64.StdEncoding.EncodeToString(raw))
-	if _, _, err := DecodeBatch(c, tampered); err == nil {
+	out := make([]byte, b64Encoding.EncodedLen(len(raw)))
+	b64Encoding.Encode(out, raw)
+	if _, _, err := DecodeBatch(c, out); err == nil {
 		t.Fatal("expected auth error on tampered batch, got nil")
+	}
+}
+
+func TestDecodeBatch_LegacyPadding(t *testing.T) {
+	c := newTestCrypto(t)
+	in := []*Frame{{SessionID: sid(1), Payload: []byte("legacy")}}
+	var zeroClient [ClientIDLen]byte
+
+	// Manually construct a padded base64 batch (like an older version would).
+	plainSize := ClientIDLen + 2 + 4 + 1 + 8 + 6 // header + u16 + u32 len + flags + sid + payload
+	plain := make([]byte, 0, plainSize)
+	plain = append(plain, zeroClient[:]...)
+	plain = append(plain, 0, 1) // count = 1
+	rawFrame, _ := in[0].Marshal()
+	plain = append(plain, byte(len(rawFrame)>>24), byte(len(rawFrame)>>16), byte(len(rawFrame)>>8), byte(len(rawFrame)))
+	plain = append(plain, rawFrame...)
+
+	sealed, _ := c.Seal(plain)
+	legacyBody := []byte(base64.StdEncoding.EncodeToString(sealed))
+
+	// Should still decode correctly.
+	gotClient, out, err := DecodeBatch(c, legacyBody)
+	if err != nil {
+		t.Fatalf("decode legacy: %v", err)
+	}
+	if gotClient != zeroClient {
+		t.Fatal("clientID mismatch")
+	}
+	if len(out) != 1 || !bytes.Equal(out[0].Payload, in[0].Payload) {
+		t.Fatal("payload mismatch")
 	}
 }


### PR DESCRIPTION
Implemented Raw Base64 Encoding across the entire framing system. Outgoing frame batches are now unpadded, saving ~1.5% in protocol overhead. The decoder is updated to be tolerant of both padded (legacy) and unpadded formats, ensuring seamless communication with older deployments. Unit tests have been updated and expanded to verify these changes. Originally found in [easyfast2008's fork](https://github.com/easyfast2008/GooseRelayVPN) but split and adapted to the latest main branch.