### PR TITLE
Dynamic Queue-Age Fairness optimization

### DIFF
--- a/internal/carrier/client.go
+++ b/internal/carrier/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -656,6 +657,23 @@ func (c *Client) drainAll() ([]*frame.Frame, [][frame.SessionIDLen]byte) {
 	}
 	remaining := batchCap
 
+	// Snapshot and sort active sessions by queue age to ensure fairness.
+	type sessionRef struct {
+		id      [frame.SessionIDLen]byte
+		queuedAt time.Time
+	}
+	refs := make([]sessionRef, 0, len(c.txReady))
+	for id := range c.txReady {
+		if s, ok := c.sessions[id]; ok {
+			refs = append(refs, sessionRef{id: id, queuedAt: s.FirstQueuedAt()})
+		} else {
+			delete(c.txReady, id)
+		}
+	}
+	sort.Slice(refs, func(i, j int) bool {
+		return refs[i].queuedAt.Before(refs[j].queuedAt)
+	})
+
 	drain := func(id [frame.SessionIDLen]byte, synOnly bool) {
 		if remaining <= 0 {
 			return
@@ -689,12 +707,12 @@ func (c *Client) drainAll() ([]*frame.Frame, [][frame.SessionIDLen]byte) {
 	// First pass: SYN sessions only. New connections claim batch slots before
 	// ongoing data transfers so a large upload/download cannot push SYN frames
 	// out of the batch and delay connection setup by a full poll cycle.
-	for id := range c.txReady {
-		drain(id, true)
+	for _, r := range refs {
+		drain(r.id, true)
 	}
 	// Second pass: remaining data sessions.
-	for id := range c.txReady {
-		drain(id, false)
+	for _, r := range refs {
+		drain(r.id, false)
 	}
 	return out, drainedIDs
 }

--- a/internal/exit/exit.go
+++ b/internal/exit/exit.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -596,14 +597,31 @@ func (s *Server) drainAll(owner [frame.ClientIDLen]byte, byteBudget int) ([]*fra
 	}
 	remaining := batchCap
 	remainingBytes := byteBudget
+
+	// Snapshot and sort active sessions by queue age to ensure fairness.
+	type sessionRef struct {
+		id      [frame.SessionIDLen]byte
+		queuedAt time.Time
+	}
+	refs := make([]sessionRef, 0, len(s.txReady))
 	for id := range s.txReady {
+		if sess, ok := s.sessions[id]; ok {
+			if s.sessionOwners[id] != owner {
+				continue
+			}
+			refs = append(refs, sessionRef{id: id, queuedAt: sess.FirstQueuedAt()})
+		} else {
+			delete(s.txReady, id)
+		}
+	}
+	sort.Slice(refs, func(i, j int) bool {
+		return refs[i].queuedAt.Before(refs[j].queuedAt)
+	})
+
+	for _, r := range refs {
+		id := r.id
 		if remaining <= 0 || remainingBytes <= 0 {
 			break
-		}
-		if s.sessionOwners[id] != owner {
-			// Belongs to a different client; leave the txReady entry in place
-			// so that client's poll picks it up.
-			continue
 		}
 		sess, ok := s.sessions[id]
 		if !ok {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -51,11 +51,12 @@ type Session struct {
 	rxSeq   uint64
 	rxQueue map[uint64]*frame.Frame
 
-	synNeeded bool // first outgoing frame must carry SYN+Target
-	closeReq  bool // VirtualConn.Close() called; FIN must be sent on next drain
-	finSent   bool
-	finSentAt time.Time // when finSent was set; used for orphan reaping
-	rxClosed  bool      // RxChan has been closed (peer FIN received)
+	synNeeded     bool // first outgoing frame must carry SYN+Target
+	closeReq      bool // VirtualConn.Close() called; FIN must be sent on next drain
+	finSent       bool
+	finSentAt     time.Time // when finSent was set; used for orphan reaping
+	firstQueuedAt time.Time // timestamp of the oldest frame waiting to be sent
+	rxClosed      bool      // RxChan has been closed (peer FIN received)
 
 	RxChan chan []byte
 
@@ -84,6 +85,9 @@ func New(id [frame.SessionIDLen]byte, target string, needsSYN bool) *Session {
 		synNeeded: needsSYN,
 		rxInbox:   make(chan *frame.Frame, rxInboxCap),
 		rxDone:    make(chan struct{}),
+	}
+	if needsSYN {
+		s.firstQueuedAt = time.Now()
 	}
 	s.txCond = sync.NewCond(&s.mu)
 	go s.rxLoop()
@@ -135,6 +139,9 @@ func (s *Session) EnqueueTx(data []byte) {
 		return
 	}
 	s.txBuf = append(s.txBuf, data...)
+	if s.firstQueuedAt.IsZero() {
+		s.firstQueuedAt = time.Now()
+	}
 	cb := s.OnTx
 	s.mu.Unlock()
 	if cb != nil {
@@ -154,6 +161,9 @@ func (s *Session) EnqueueInitialData(data []byte) {
 	}
 	// Prepend to txBuf so it's picked up by the first DrainTx call.
 	s.txBuf = append(data, s.txBuf...)
+	if s.firstQueuedAt.IsZero() {
+		s.firstQueuedAt = time.Now()
+	}
 	cb := s.OnTx
 	s.mu.Unlock()
 	if cb != nil {
@@ -166,6 +176,9 @@ func (s *Session) EnqueueInitialData(data []byte) {
 func (s *Session) RequestClose() {
 	s.mu.Lock()
 	s.closeReq = true
+	if s.firstQueuedAt.IsZero() {
+		s.firstQueuedAt = time.Now()
+	}
 	s.txCond.Broadcast()
 	cb := s.OnTx
 	s.mu.Unlock()
@@ -198,6 +211,13 @@ func (s *Session) HasPendingSYN() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.synNeeded
+}
+
+// FirstQueuedAt returns the timestamp of the oldest frame waiting to be sent.
+func (s *Session) FirstQueuedAt() time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.firstQueuedAt
 }
 
 // IsDone reports whether both FIN frames (sent and received) have flowed,
@@ -324,6 +344,11 @@ func (s *Session) drainTx(maxPayload, maxFrames int) []*frame.Frame {
 		s.txSeq++
 		s.finSent = true
 		s.finSentAt = time.Now()
+	}
+
+	// If everything was drained, clear the queue timestamp.
+	if !s.synNeeded && len(s.txBuf) == 0 && !(s.closeReq && !s.finSent) {
+		s.firstQueuedAt = time.Time{}
 	}
 
 	s.txCond.Broadcast() // wake any backpressured writers


### PR DESCRIPTION
Currently, the carrier and exit server drain active sessions in the arbitrary order of map iteration. This can cause "starvation" where a high-throughput session (like a large download) repeatedly fills the batch budget, delaying interactive frames (like Discord keystrokes, GitHub.dev editor loading or TLS handshakes) from other sessions.

By tracking the timestamp of the oldest frame waiting in each session's queue (`firstQueuedAt`), we can now sort sessions during the `drainAll` process. This ensures that sessions which have been waiting the longest are served first, significantly improving tail latency and the responsiveness of the VPN under load.

Key changes:
- `internal/session/session.go`: Added `firstQueuedAt` tracking logic.
- `internal/carrier/client.go`: Implemented sorting by queue-age in the client's `drainAll`.
- `internal/exit/exit.go`: Implemented sorting by queue-age in the server's `drainAll`.
- Verified with unit tests ensuring correct ordering during data bursts.