### PR TITLE
feature/docker-integration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+.gitignore
+.DS_Store
+**/.DS_Store
+bin
+dist
+tmp
+*.tmp
+*.swp
+*.swo
+bench/results
+README_FA.md
+*.log

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,53 @@
+name: Docker Publish
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Publish GHCR image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/gooserelayvpn-server
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          build-args: |
+            VERSION=${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM golang:1.22-alpine AS builder
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG VERSION=dev
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -trimpath -ldflags "-s -w -X main.version=${VERSION}" -o /out/goose-server ./cmd/server
+
+FROM gcr.io/distroless/static-debian12:nonroot
+
+WORKDIR /app
+
+COPY --from=builder /out/goose-server /app/goose-server
+COPY server_config.example.json /app/server_config.example.json
+
+EXPOSE 8443
+
+ENTRYPOINT ["/app/goose-server"]
+CMD ["-config", "/app/server_config.json"]

--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ You should see it print the listening address and the healthz/tunnel URLs. Leave
 
 **Docker (GHCR image):**
 
+> ⚠️ **Important:** The container does **not** auto-generate `server_config.json`. You must create and edit `server_config.json` first (with your own `tunnel_key`), then start the container.
+
 ```bash
 docker run -d \
   --name goose-server \

--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ go build -o goose-client ./cmd/client
 go build -o goose-server ./cmd/server
 ```
 
+**Option C — Run only the server with Docker (GHCR):**
+
+If you prefer containers on your VPS, you can run `goose-server` directly from GHCR:
+
+```bash
+docker pull ghcr.io/kianmhz/gooserelayvpn-server:latest
+```
+
 ### Step 3: Generate a secret key
 
 Run this once:
@@ -203,6 +211,37 @@ On your VPS, run the server binary:
 ```
 
 You should see it print the listening address and the healthz/tunnel URLs. Leave this terminal open, or set up the systemd/NSSM service (Step 8) to keep it running after reboots.
+
+**Docker (GHCR image):**
+
+```bash
+docker run -d \
+  --name goose-server \
+  --restart unless-stopped \
+  -p 8443:8443 \
+  -v $(pwd)/server_config.json:/app/server_config.json:ro \
+  ghcr.io/kianmhz/gooserelayvpn-server:latest
+```
+
+**Docker Compose (recommended for container setup):**
+
+```bash
+cp server_config.example.json server_config.json
+nano server_config.json
+docker compose up -d
+```
+
+The repo includes [`docker-compose.yml`](docker-compose.yml). By default it uses `ghcr.io/kianmhz/gooserelayvpn-server:latest`, and you can override it with:
+
+```bash
+GOOSE_SERVER_IMAGE=ghcr.io/kianmhz/gooserelayvpn-server:vX.Y.Z docker compose up -d
+```
+
+Verify from your own computer:
+
+```bash
+curl http://YOUR.VPS.IP:8443/healthz
+```
 
 ### Step 8: Keep the server running after reboot (systemd)
 

--- a/README_FA.md
+++ b/README_FA.md
@@ -214,6 +214,8 @@ curl http://YOUR.VPS.IP:8443/healthz
 
 **Docker (ایمیج GHCR):**
 
+> ⚠️ **مهم:** کانتینر فایل `server_config.json` را به‌صورت خودکار نمی‌سازد. باید قبل از اجرا، `server_config.json` را خودتان بسازید و با `tunnel_key` خودتان پر کنید.
+
 ```bash
 docker run -d \
   --name goose-server \

--- a/README_FA.md
+++ b/README_FA.md
@@ -110,6 +110,14 @@ go build -o goose-client ./cmd/client
 go build -o goose-server ./cmd/server
 ```
 
+**گزینه C — اجرای فقط سرور با Docker (GHCR):**
+
+اگر روی VPS استفاده از کانتینر را ترجیح می‌دهید، می‌توانید `goose-server` را مستقیم از GHCR اجرا کنید:
+
+```bash
+docker pull ghcr.io/kianmhz/gooserelayvpn-server:latest
+```
+
 ### مرحله ۳: ساخت یک کلید مخفی
 
 این دستور را یک‌بار اجرا کنید:
@@ -203,6 +211,37 @@ curl http://YOUR.VPS.IP:8443/healthz
 ```
 
 باید آدرس listening و آدرس‌های healthz/tunnel را ببینید. این ترمینال را باز بگذارید، یا مرحله ۸ را انجام دهید تا بعد از ریبوت هم بالا بماند.
+
+**Docker (ایمیج GHCR):**
+
+```bash
+docker run -d \
+  --name goose-server \
+  --restart unless-stopped \
+  -p 8443:8443 \
+  -v $(pwd)/server_config.json:/app/server_config.json:ro \
+  ghcr.io/kianmhz/gooserelayvpn-server:latest
+```
+
+**Docker Compose (پیشنهادی برای راه‌اندازی کانتینری):**
+
+```bash
+cp server_config.example.json server_config.json
+nano server_config.json
+docker compose up -d
+```
+
+فایل [`docker-compose.yml`](docker-compose.yml) داخل مخزن آماده است. به‌صورت پیش‌فرض از `ghcr.io/kianmhz/gooserelayvpn-server:latest` استفاده می‌کند و برای پین کردن نسخه می‌توانید override کنید:
+
+```bash
+GOOSE_SERVER_IMAGE=ghcr.io/kianmhz/gooserelayvpn-server:vX.Y.Z docker compose up -d
+```
+
+تست از روی کامپیوتر خودتان:
+
+```bash
+curl http://YOUR.VPS.IP:8443/healthz
+```
 
 ### مرحله ۸: اجرای خودکار سرور بعد از ریبوت (systemd)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  goose-server:
+    image: ${GOOSE_SERVER_IMAGE:-ghcr.io/kianmhz/gooserelayvpn-server:latest}
+    container_name: goose-server
+    restart: unless-stopped
+    ports:
+      - "8443:8443"
+    volumes:
+      - ./server_config.json:/app/server_config.json:ro


### PR DESCRIPTION
## Summary
- Adds Docker support for running `goose-server` with a production-ready `Dockerfile` and `docker-compose.yml`.
- Adds a new GitHub Actions workflow (`.github/workflows/docker-publish.yml`) to publish multi-arch GHCR images on `v*` tags only.
- Updates both READMEs (`README.md`, `README_FA.md`) with Docker/Compose setup and an explicit note that `server_config.json` must be created manually before container startup.

## Package test
You can test the published container from this package page:  
https://github.com/NikanZeyaei/GooseRelayVPN/pkgs/container/gooserelayvpn-server
