### PR TITLE
Added server installer/updater

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -131,11 +131,17 @@ const gooseBanner = `
 `
 
 func main() {
+	configPath := flag.String("config", "client_config.json", "path to client config JSON")
+	showVersion := flag.Bool("version", false, "show version and exit")
+	flag.Parse()
+
+	if *showVersion {
+		fmt.Println(version)
+		return
+	}
+
 	fmt.Print(gooseBanner)
 	setupClientLogging()
-
-	configPath := flag.String("config", "client_config.json", "path to client config JSON")
-	flag.Parse()
 
 	cfg, err := config.LoadClient(*configPath)
 	if err != nil {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"net"
 	"strings"
@@ -16,7 +17,13 @@ var version = "dev"
 
 func main() {
 	configPath := flag.String("config", "server_config.json", "path to server config JSON")
+	showVersion := flag.Bool("version", false, "show version and exit")
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Println(version)
+		return
+	}
 
 	cfg, err := config.LoadServer(*configPath)
 	if err != nil {

--- a/scripts/goose-server.sh
+++ b/scripts/goose-server.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# GooseRelayVPN Server Installer
+# GooseRelayVPN Server Installer & Manager
 # Repository: https://github.com/Kianmhz/GooseRelayVPN
 
 set -e
@@ -56,107 +56,129 @@ get_latest_version() {
     curl -s "https://api.github.com/repos/$REPO/releases/latest" | jq -r .tag_name
 }
 
-# Function to get installed version
-get_installed_version() {
-    # 1. Try to get version from binary using -version flag
-    if [ -f "$INSTALL_DIR/$BINARY_NAME" ]; then
-        BIN_VERSION=$("$INSTALL_DIR/$BINARY_NAME" -version 2>/dev/null | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" || echo "")
-        if [ -n "$BIN_VERSION" ]; then
-            echo "$BIN_VERSION"
-            return
-        fi
-        
-        # 2. Try to get version from running server's /healthz
-        if [ -f "$INSTALL_DIR/$CONFIG_NAME" ]; then
-            PORT=$(jq -r '.server_port // 8443' "$INSTALL_DIR/$CONFIG_NAME" 2>/dev/null || echo "8443")
-            HEALTH_VERSION=$(curl -s --max-time 2 "http://127.0.0.1:$PORT/healthz" | jq -r '.version' 2>/dev/null || echo "")
-            if [[ "$HEALTH_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-                echo "$HEALTH_VERSION"
-                return
-            fi
-        fi
-
-        # 3. Try to extract version string from binary using 'strings' (for older versions)
-        # We look for something like v1.5.0 at the end of a line
-        BIN_STRINGS_VERSION=$(strings "$INSTALL_DIR/$BINARY_NAME" | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" | head -n 1 || echo "")
-        if [ -n "$BIN_STRINGS_VERSION" ]; then
-            echo "$BIN_STRINGS_VERSION"
-            return
-        fi
-    fi
+# Function to get version of a binary
+get_bin_version() {
+    local bin_path=$1
+    if [ ! -f "$bin_path" ]; then echo "none"; return; fi
     
-    # 4. Fallback to .version file
-    if [ -f "$INSTALL_DIR/.version" ]; then
-        cat "$INSTALL_DIR/.version"
-    else
-        echo "unknown"
+    # 1. Try -version flag
+    local ver=$("$bin_path" -version 2>/dev/null | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" || echo "")
+    if [ -n "$ver" ]; then echo "$ver"; return; fi
+    
+    # 2. Try strings extraction
+    ver=$(strings "$bin_path" | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" | head -n 1 || echo "")
+    if [ -n "$ver" ]; then echo "$ver"; return; fi
+    
+    echo "unknown"
+}
+
+# Function to discover existing installation
+discover_existing() {
+    # Check our standard path first
+    if [ -f "$INSTALL_DIR/$BINARY_NAME" ]; then
+        EXISTING_BIN="$INSTALL_DIR/$BINARY_NAME"
+        EXISTING_DIR="$INSTALL_DIR"
+        return
     fi
+
+    echo -e "${YELLOW}Checking for existing GooseRelayVPN installations...${NC}"
+    
+    # Check running processes
+    local p_path=$(pgrep -af "$BINARY_NAME" | grep -v "$0" | awk '{print $2}' | head -n 1 || echo "")
+    if [ -n "$p_path" ] && [ -f "$p_path" ]; then
+        EXISTING_BIN="$p_path"
+        EXISTING_DIR=$(dirname "$p_path")
+        return
+    fi
+
+    # Check systemd services
+    local s_path=$(systemctl show -p FragmentPath "$SERVICE_NAME" 2>/dev/null | cut -d= -f2)
+    if [ -n "$s_path" ] && [ -f "$s_path" ]; then
+        local exec_line=$(grep "ExecStart=" "$s_path" | cut -d= -f2 | awk '{print $1}')
+        if [ -n "$exec_line" ] && [ -f "$exec_line" ]; then
+            EXISTING_BIN="$exec_line"
+            EXISTING_DIR=$(dirname "$exec_line")
+            return
+        fi
+    fi
+
+    # Common locations
+    LOCATIONS=("/usr/local/bin/$BINARY_NAME" "/usr/bin/$BINARY_NAME" "/root/$BINARY_NAME")
+    for loc in "${LOCATIONS[@]}"; do
+        if [ -f "$loc" ]; then
+            EXISTING_BIN="$loc"
+            EXISTING_DIR=$(dirname "$loc")
+            return
+        fi
+    done
 }
 
 # Function to detect platform
 get_platform() {
     OS=$(uname -s | tr '[:upper:]' '[:lower:]')
     ARCH=$(uname -m)
-    
     case "$ARCH" in
         x86_64) ARCH="amd64" ;;
         aarch64) ARCH="arm64" ;;
         armv7l) ARCH="armv7" ;;
         *) echo -e "${RED}Unsupported architecture: $ARCH${NC}"; exit 1 ;;
     esac
-    
     echo "${OS}-${ARCH}"
 }
 
-# Function to install the server
-install_server() {
-    if [ -f "$INSTALL_DIR/$BINARY_NAME" ]; then
-        echo -e "${YELLOW}GooseRelayVPN is already installed.${NC}"
-        read -p "Do you want to reinstall? (y/n): " choice
-        if [[ "$choice" != "y" ]]; then return; fi
+# Function to install/update the server
+install_or_update() {
+    local is_update=$1
+    discover_existing
+    
+    LATEST_VERSION=$(get_latest_version)
+    
+    if [ -n "$EXISTING_BIN" ]; then
+        CURRENT_VERSION=$(get_bin_version "$EXISTING_BIN")
+        echo -e "Found existing installation at ${YELLOW}$EXISTING_BIN${NC} (Version: ${GREEN}$CURRENT_VERSION${NC})"
+        
+        if [ "$CURRENT_VERSION" == "$LATEST_VERSION" ] && [ "$is_update" == "true" ]; then
+            echo -e "${GREEN}GooseRelayVPN is already up to date.${NC}"
+            read -p "Force update anyway? (y/n): " force
+            if [[ "$force" != "y" ]]; then return; fi
+        fi
+
+        if [ "$EXISTING_DIR" != "$INSTALL_DIR" ]; then
+            echo -e "${YELLOW}Migration needed:${NC} Existing installation is in $EXISTING_DIR. Will move to $INSTALL_DIR."
+            read -p "Proceed with migration and update? (y/n): " proceed
+            if [[ "$proceed" != "y" ]]; then return; fi
+        fi
+    else
+        if [ "$is_update" == "true" ]; then
+            echo -e "${RED}No existing installation found to update.${NC}"
+            return
+        fi
+        echo -e "${YELLOW}Installing GooseRelayVPN $LATEST_VERSION...${NC}"
     fi
 
     check_dependencies
     
-    VERSION=$(get_latest_version)
-    PLATFORM=$(get_platform)
-    DOWNLOAD_URL="https://github.com/$REPO/releases/download/$VERSION/GooseRelayVPN-server-$VERSION-$PLATFORM.tar.gz"
-    
-    echo -e "${YELLOW}Downloading GooseRelayVPN $VERSION for $PLATFORM...${NC}"
-    mkdir -p "$INSTALL_DIR"
-    curl -L "$DOWNLOAD_URL" -o "/tmp/goose.tar.gz"
-    tar -xzf "/tmp/goose.tar.gz" -C "$INSTALL_DIR"
-    rm "/tmp/goose.tar.gz"
-    echo "$VERSION" > "$INSTALL_DIR/.version"
-    
-    # Check if we got the binary (sometimes it's inside a folder in the tar)
-    if [ ! -f "$INSTALL_DIR/$BINARY_NAME" ]; then
-        # Try to find it
-        FIND_BIN=$(find "$INSTALL_DIR" -name "$BINARY_NAME" -type f | head -n 1)
-        if [ -n "$FIND_BIN" ]; then
-            mv "$FIND_BIN" "$INSTALL_DIR/$BINARY_NAME"
-        else
-            echo -e "${RED}Error: Binary not found after extraction.${NC}"
-            exit 1
-        fi
-    fi
-    chmod +x "$INSTALL_DIR/$BINARY_NAME"
+    # 1. Shutdown if running
+    echo -e "${YELLOW}Stopping service...${NC}"
+    systemctl stop "$SERVICE_NAME" 2>/dev/null || true
+    # Also kill any orphaned processes
+    pkill -f "$BINARY_NAME" || true
 
-    # Configuration
-    if [ ! -f "$INSTALL_DIR/$CONFIG_NAME" ]; then
-        echo -e "${YELLOW}Creating configuration...${NC}"
-        # Fetch example config if not exists
+    # 2. Prepare directory
+    mkdir -p "$INSTALL_DIR"
+    
+    # 3. Handle config migration/creation
+    if [ -n "$EXISTING_DIR" ] && [ -f "$EXISTING_DIR/$CONFIG_NAME" ] && [ "$EXISTING_DIR" != "$INSTALL_DIR" ]; then
+        echo -e "${YELLOW}Migrating configuration from $EXISTING_DIR...${NC}"
+        cp "$EXISTING_DIR/$CONFIG_NAME" "$INSTALL_DIR/$CONFIG_NAME"
+    elif [ ! -f "$INSTALL_DIR/$CONFIG_NAME" ]; then
+        echo -e "${YELLOW}Creating fresh configuration...${NC}"
         curl -s "https://raw.githubusercontent.com/$REPO/main/server_config.example.json" -o "$INSTALL_DIR/$CONFIG_NAME"
-        
         TUNNEL_KEY=$(openssl rand -hex 32)
-        
-        # Use jq for more robust JSON manipulation
         jq --arg key "$TUNNEL_KEY" '.tunnel_key = $key' "$INSTALL_DIR/$CONFIG_NAME" > "$INSTALL_DIR/$CONFIG_NAME.tmp" && mv "$INSTALL_DIR/$CONFIG_NAME.tmp" "$INSTALL_DIR/$CONFIG_NAME"
-        
         echo -e "${GREEN}Generated tunnel_key: $TUNNEL_KEY${NC}"
-        echo -e "${YELLOW}PLEASE COPY AND SAVE THIS KEY FOR CLIENT CONFIGURATION!${NC}"
         
-        echo -e "\nRoute all outbound connections through a local SOCKS5 proxy? (Useful for Cloudflare WARP)"
+        echo -e "\nRoute all outbound connections through a local SOCKS5 proxy? (Cloudflare WARP)"
         read -p "Activate upstream_proxy? (y/n): " use_proxy
         if [[ "$use_proxy" == "y" ]]; then
             jq '.upstream_proxy = "socks5://127.0.0.1:40000"' "$INSTALL_DIR/$CONFIG_NAME" > "$INSTALL_DIR/$CONFIG_NAME.tmp" && mv "$INSTALL_DIR/$CONFIG_NAME.tmp" "$INSTALL_DIR/$CONFIG_NAME"
@@ -165,19 +187,33 @@ install_server() {
         fi
     fi
 
-    # Systemd Service
+    # 4. Download and Install Binary
+    PLATFORM=$(get_platform)
+    DOWNLOAD_URL="https://github.com/$REPO/releases/download/$LATEST_VERSION/GooseRelayVPN-server-$LATEST_VERSION-$PLATFORM.tar.gz"
+    echo -e "${YELLOW}Downloading $LATEST_VERSION for $PLATFORM...${NC}"
+    curl -L "$DOWNLOAD_URL" -o "/tmp/goose.tar.gz"
+    tar -xzf "/tmp/goose.tar.gz" -C "$INSTALL_DIR"
+    rm "/tmp/goose.tar.gz"
+    echo "$LATEST_VERSION" > "$INSTALL_DIR/.version"
+
+    if [ ! -f "$INSTALL_DIR/$BINARY_NAME" ]; then
+        FIND_BIN=$(find "$INSTALL_DIR" -name "$BINARY_NAME" -type f | head -n 1)
+        [ -n "$FIND_BIN" ] && mv "$FIND_BIN" "$INSTALL_DIR/$BINARY_NAME"
+    fi
+    chmod +x "$INSTALL_DIR/$BINARY_NAME"
+
+    # 5. Setup/Update Service
     create_service
     
-    # Firewall
+    # 6. Firewall
     configure_firewall
 
-    echo -e "${GREEN}GooseRelayVPN installation complete!${NC}"
+    echo -e "${GREEN}GooseRelayVPN is now running from $INSTALL_DIR!${NC}"
     systemctl status "$SERVICE_NAME" --no-pager
 }
 
-# Function to create/update systemd service
 create_service() {
-    echo -e "${YELLOW}Setting up systemd service...${NC}"
+    echo -e "${YELLOW}Configuring systemd service...${NC}"
     cat <<EOF > /etc/systemd/system/$SERVICE_NAME.service
 [Unit]
 Description=GooseRelayVPN exit server
@@ -200,129 +236,68 @@ EOF
     systemctl restart "$SERVICE_NAME"
 }
 
-# Function to configure firewall
 configure_firewall() {
     PORT=$(jq -r '.server_port // 8443' "$INSTALL_DIR/$CONFIG_NAME")
-    echo -e "${YELLOW}Opening port $PORT...${NC}"
     if command -v ufw &> /dev/null; then
         ufw allow "$PORT"/tcp
     elif command -v iptables &> /dev/null; then
         iptables -A INPUT -p tcp --dport "$PORT" -j ACCEPT
-    else
-        echo -e "${YELLOW}No ufw or iptables found. Please open port $PORT manually.${NC}"
     fi
 }
 
-# Function to update the server
-update_server() {
-    if [ ! -f "$INSTALL_DIR/$BINARY_NAME" ]; then
-        echo -e "${RED}GooseRelayVPN is not installed. Use install option instead.${NC}"
+uninstall_server() {
+    discover_existing
+    if [ -z "$EXISTING_BIN" ]; then
+        echo -e "${RED}GooseRelayVPN is not installed.${NC}"
         return
     fi
-
-    check_dependencies
-    CURRENT_VERSION=$(get_installed_version)
-    LATEST_VERSION=$(get_latest_version)
-
-    if [ "$CURRENT_VERSION" == "$LATEST_VERSION" ]; then
-        echo -e "${GREEN}GooseRelayVPN is already up to date ($CURRENT_VERSION).${NC}"
-        read -p "Do you want to force update anyway? (y/n): " choice
-        if [[ "$choice" != "y" ]]; then return; fi
-    else
-        echo -e "${YELLOW}A new version is available: $LATEST_VERSION (Current: $CURRENT_VERSION)${NC}"
-        read -p "Do you want to update? (y/n): " choice
-        if [[ "$choice" != "y" ]]; then return; fi
-    fi
-
-    PLATFORM=$(get_platform)
-    DOWNLOAD_URL="https://github.com/$REPO/releases/download/$LATEST_VERSION/GooseRelayVPN-server-$LATEST_VERSION-$PLATFORM.tar.gz"
-    
-    echo -e "${YELLOW}Downloading update $LATEST_VERSION...${NC}"
-    curl -L "$DOWNLOAD_URL" -o "/tmp/goose.tar.gz"
-    
-    # Stop service before updating
-    systemctl stop "$SERVICE_NAME" || true
-    
-    tar -xzf "/tmp/goose.tar.gz" -C "$INSTALL_DIR"
-    rm "/tmp/goose.tar.gz"
-    echo "$LATEST_VERSION" > "$INSTALL_DIR/.version"
-    
-    # Binary placement check again
-    if [ ! -f "$INSTALL_DIR/$BINARY_NAME" ]; then
-        FIND_BIN=$(find "$INSTALL_DIR" -name "$BINARY_NAME" -type f | head -n 1)
-        if [ -n "$FIND_BIN" ]; then
-            mv "$FIND_BIN" "$INSTALL_DIR/$BINARY_NAME"
-        fi
-    fi
-    chmod +x "$INSTALL_DIR/$BINARY_NAME"
-    
-    systemctl start "$SERVICE_NAME"
-    echo -e "${GREEN}Update complete!${NC}"
-}
-
-# Function to uninstall
-uninstall_server() {
-    read -p "Are you sure you want to uninstall GooseRelayVPN? (y/n): " choice
+    read -p "Uninstall GooseRelayVPN from $EXISTING_DIR? (y/n): " choice
     if [[ "$choice" == "y" ]]; then
-        echo -e "${YELLOW}Uninstalling...${NC}"
         systemctl stop "$SERVICE_NAME" || true
         systemctl disable "$SERVICE_NAME" || true
         rm -f /etc/systemd/system/$SERVICE_NAME.service
         systemctl daemon-reload
-        
         rm -rf "$INSTALL_DIR"
-        echo -e "${GREEN}GooseRelayVPN uninstalled successfully.${NC}"
+        # If it was elsewhere, we don't necessarily want to rm -rf that entire dir
+        # but we should remove the binary
+        [ "$EXISTING_DIR" != "$INSTALL_DIR" ] && rm -f "$EXISTING_BIN"
+        echo -e "${GREEN}Uninstalled successfully.${NC}"
     fi
 }
 
-# Function to reconfigure
 reconfigure_server() {
     if [ ! -f "$INSTALL_DIR/$CONFIG_NAME" ]; then
-        echo -e "${RED}Configuration file not found.${NC}"
+        echo -e "${RED}Configuration not found at $INSTALL_DIR/$CONFIG_NAME${NC}"
         return
     fi
-    
     echo "1) Regenerate tunnel_key"
-    echo "2) Enable/Disable upstream_proxy"
-    read -p "Select an option: " choice
-    
+    echo "2) Toggle upstream_proxy"
+    read -p "Choice: " choice
     case $choice in
         1)
             NEW_KEY=$(openssl rand -hex 32)
             jq --arg key "$NEW_KEY" '.tunnel_key = $key' "$INSTALL_DIR/$CONFIG_NAME" > "$INSTALL_DIR/$CONFIG_NAME.tmp" && mv "$INSTALL_DIR/$CONFIG_NAME.tmp" "$INSTALL_DIR/$CONFIG_NAME"
-            echo -e "${GREEN}New tunnel_key generated: $NEW_KEY${NC}"
-            echo -e "${YELLOW}Remember to update your client config!${NC}"
+            echo -e "${GREEN}New tunnel_key: $NEW_KEY${NC}"
             systemctl restart "$SERVICE_NAME"
             ;;
         2)
             HAS_PROXY=$(jq '.upstream_proxy' "$INSTALL_DIR/$CONFIG_NAME")
             if [ "$HAS_PROXY" != "null" ]; then
-                echo "Upstream proxy is currently enabled ($HAS_PROXY)."
-                read -p "Disable it? (y/n): " dis
-                if [[ "$dis" == "y" ]]; then
-                    jq 'del(.upstream_proxy)' "$INSTALL_DIR/$CONFIG_NAME" > "$INSTALL_DIR/$CONFIG_NAME.tmp" && mv "$INSTALL_DIR/$CONFIG_NAME.tmp" "$INSTALL_DIR/$CONFIG_NAME"
-                    echo "Upstream proxy disabled."
-                fi
+                jq 'del(.upstream_proxy)' "$INSTALL_DIR/$CONFIG_NAME" > "$INSTALL_DIR/$CONFIG_NAME.tmp" && mv "$INSTALL_DIR/$CONFIG_NAME.tmp" "$INSTALL_DIR/$CONFIG_NAME"
+                echo "Upstream proxy disabled."
             else
-                echo "Upstream proxy is currently disabled."
-                read -p "Enable it? (y/n): " en
-                if [[ "$en" == "y" ]]; then
-                    jq '.upstream_proxy = "socks5://127.0.0.1:40000"' "$INSTALL_DIR/$CONFIG_NAME" > "$INSTALL_DIR/$CONFIG_NAME.tmp" && mv "$INSTALL_DIR/$CONFIG_NAME.tmp" "$INSTALL_DIR/$CONFIG_NAME"
-                    echo "Upstream proxy enabled."
-                fi
+                jq '.upstream_proxy = "socks5://127.0.0.1:40000"' "$INSTALL_DIR/$CONFIG_NAME" > "$INSTALL_DIR/$CONFIG_NAME.tmp" && mv "$INSTALL_DIR/$CONFIG_NAME.tmp" "$INSTALL_DIR/$CONFIG_NAME"
+                echo "Upstream proxy enabled."
             fi
             systemctl restart "$SERVICE_NAME"
             ;;
-        *) echo "Invalid option";;
     esac
 }
 
-# Main execution loop
 if [ "$#" -gt 0 ]; then
-    # Non-interactive mode if needed
     case $1 in
-        install) install_server ;;
-        update) update_server ;;
+        install) install_or_update "false" ;;
+        update) install_or_update "true" ;;
         uninstall) uninstall_server ;;
         *) show_menu ;;
     esac
@@ -331,12 +306,11 @@ else
         show_menu
         read -p "Enter choice [1-5]: " choice
         case $choice in
-            1) install_server ;;
-            2) update_server ;;
+            1) install_or_update "false" ;;
+            2) install_or_update "true" ;;
             3) uninstall_server ;;
             4) reconfigure_server ;;
             5) exit 0 ;;
-            *) echo -e "${RED}Invalid option${NC}" ;;
         esac
         echo ""
     done

--- a/scripts/goose-server.sh
+++ b/scripts/goose-server.sh
@@ -1,0 +1,315 @@
+#!/bin/bash
+
+# GooseRelayVPN Server Installer
+# Repository: https://github.com/Kianmhz/GooseRelayVPN
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+INSTALL_DIR="/root/goose"
+SERVICE_NAME="goose-relay"
+REPO="Kianmhz/GooseRelayVPN"
+BINARY_NAME="goose-server"
+CONFIG_NAME="server_config.json"
+
+# Check if running as root
+if [[ $EUID -ne 0 ]]; then
+   echo -e "${RED}This script must be run as root${NC}"
+   exit 1
+fi
+
+# Function to display the menu
+show_menu() {
+    echo -e "${GREEN}GooseRelayVPN Server Management Script${NC}"
+    echo "1) Install GooseRelayVPN"
+    echo "2) Update GooseRelayVPN"
+    echo "3) Uninstall GooseRelayVPN"
+    echo "4) Reconfigure GooseRelayVPN"
+    echo "5) Exit"
+}
+
+# Function to check dependencies
+check_dependencies() {
+    echo -e "${YELLOW}Checking dependencies...${NC}"
+    DEPS=("curl" "tar" "openssl" "jq")
+    MISSING_DEPS=()
+    for dep in "${DEPS[@]}"; do
+        if ! command -v "$dep" &> /dev/null; then
+            MISSING_DEPS+=("$dep")
+        fi
+    done
+
+    if [ ${#MISSING_DEPS[@]} -gt 0 ]; then
+        echo -e "${YELLOW}Installing missing dependencies: ${MISSING_DEPS[*]}...${NC}"
+        apt-get update
+        apt-get install -y "${MISSING_DEPS[@]}"
+    fi
+}
+
+# Function to get latest version from GitHub
+get_latest_version() {
+    curl -s "https://api.github.com/repos/$REPO/releases/latest" | jq -r .tag_name
+}
+
+# Function to get installed version
+get_installed_version() {
+    if [ -f "$INSTALL_DIR/.version" ]; then
+        cat "$INSTALL_DIR/.version"
+    else
+        echo "unknown"
+    fi
+}
+
+# Function to detect platform
+get_platform() {
+    OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+    ARCH=$(uname -m)
+    
+    case "$ARCH" in
+        x86_64) ARCH="amd64" ;;
+        aarch64) ARCH="arm64" ;;
+        armv7l) ARCH="armv7" ;;
+        *) echo -e "${RED}Unsupported architecture: $ARCH${NC}"; exit 1 ;;
+    esac
+    
+    echo "${OS}-${ARCH}"
+}
+
+# Function to install the server
+install_server() {
+    if [ -f "$INSTALL_DIR/$BINARY_NAME" ]; then
+        echo -e "${YELLOW}GooseRelayVPN is already installed.${NC}"
+        read -p "Do you want to reinstall? (y/n): " choice
+        if [[ "$choice" != "y" ]]; then return; fi
+    fi
+
+    check_dependencies
+    
+    VERSION=$(get_latest_version)
+    PLATFORM=$(get_platform)
+    DOWNLOAD_URL="https://github.com/$REPO/releases/download/$VERSION/GooseRelayVPN-server-$VERSION-$PLATFORM.tar.gz"
+    
+    echo -e "${YELLOW}Downloading GooseRelayVPN $VERSION for $PLATFORM...${NC}"
+    mkdir -p "$INSTALL_DIR"
+    curl -L "$DOWNLOAD_URL" -o "/tmp/goose.tar.gz"
+    tar -xzf "/tmp/goose.tar.gz" -C "$INSTALL_DIR"
+    rm "/tmp/goose.tar.gz"
+    echo "$VERSION" > "$INSTALL_DIR/.version"
+    
+    # Check if we got the binary (sometimes it's inside a folder in the tar)
+    if [ ! -f "$INSTALL_DIR/$BINARY_NAME" ]; then
+        # Try to find it
+        FIND_BIN=$(find "$INSTALL_DIR" -name "$BINARY_NAME" -type f | head -n 1)
+        if [ -n "$FIND_BIN" ]; then
+            mv "$FIND_BIN" "$INSTALL_DIR/$BINARY_NAME"
+        else
+            echo -e "${RED}Error: Binary not found after extraction.${NC}"
+            exit 1
+        fi
+    fi
+    chmod +x "$INSTALL_DIR/$BINARY_NAME"
+
+    # Configuration
+    if [ ! -f "$INSTALL_DIR/$CONFIG_NAME" ]; then
+        echo -e "${YELLOW}Creating configuration...${NC}"
+        # Fetch example config if not exists
+        curl -s "https://raw.githubusercontent.com/$REPO/main/server_config.example.json" -o "$INSTALL_DIR/$CONFIG_NAME"
+        
+        TUNNEL_KEY=$(openssl rand -hex 32)
+        
+        # Use jq for more robust JSON manipulation
+        jq --arg key "$TUNNEL_KEY" '.tunnel_key = $key' "$INSTALL_DIR/$CONFIG_NAME" > "$INSTALL_DIR/$CONFIG_NAME.tmp" && mv "$INSTALL_DIR/$CONFIG_NAME.tmp" "$INSTALL_DIR/$CONFIG_NAME"
+        
+        echo -e "${GREEN}Generated tunnel_key: $TUNNEL_KEY${NC}"
+        echo -e "${YELLOW}PLEASE COPY AND SAVE THIS KEY FOR CLIENT CONFIGURATION!${NC}"
+        
+        echo -e "\nRoute all outbound connections through a local SOCKS5 proxy? (Useful for Cloudflare WARP)"
+        read -p "Activate upstream_proxy? (y/n): " use_proxy
+        if [[ "$use_proxy" == "y" ]]; then
+            jq '.upstream_proxy = "socks5://127.0.0.1:40000"' "$INSTALL_DIR/$CONFIG_NAME" > "$INSTALL_DIR/$CONFIG_NAME.tmp" && mv "$INSTALL_DIR/$CONFIG_NAME.tmp" "$INSTALL_DIR/$CONFIG_NAME"
+        else
+            jq 'del(.upstream_proxy)' "$INSTALL_DIR/$CONFIG_NAME" > "$INSTALL_DIR/$CONFIG_NAME.tmp" && mv "$INSTALL_DIR/$CONFIG_NAME.tmp" "$INSTALL_DIR/$CONFIG_NAME"
+        fi
+    fi
+
+    # Systemd Service
+    create_service
+    
+    # Firewall
+    configure_firewall
+
+    echo -e "${GREEN}GooseRelayVPN installation complete!${NC}"
+    systemctl status "$SERVICE_NAME" --no-pager
+}
+
+# Function to create/update systemd service
+create_service() {
+    echo -e "${YELLOW}Setting up systemd service...${NC}"
+    cat <<EOF > /etc/systemd/system/$SERVICE_NAME.service
+[Unit]
+Description=GooseRelayVPN exit server
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=$INSTALL_DIR
+ExecStart=$INSTALL_DIR/$BINARY_NAME -config $INSTALL_DIR/$CONFIG_NAME
+Restart=always
+RestartSec=3
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    systemctl daemon-reload
+    systemctl enable "$SERVICE_NAME"
+    systemctl restart "$SERVICE_NAME"
+}
+
+# Function to configure firewall
+configure_firewall() {
+    PORT=$(jq -r '.server_port // 8443' "$INSTALL_DIR/$CONFIG_NAME")
+    echo -e "${YELLOW}Opening port $PORT...${NC}"
+    if command -v ufw &> /dev/null; then
+        ufw allow "$PORT"/tcp
+    elif command -v iptables &> /dev/null; then
+        iptables -A INPUT -p tcp --dport "$PORT" -j ACCEPT
+    else
+        echo -e "${YELLOW}No ufw or iptables found. Please open port $PORT manually.${NC}"
+    fi
+}
+
+# Function to update the server
+update_server() {
+    if [ ! -f "$INSTALL_DIR/$BINARY_NAME" ]; then
+        echo -e "${RED}GooseRelayVPN is not installed. Use install option instead.${NC}"
+        return
+    fi
+
+    check_dependencies
+    CURRENT_VERSION=$(get_installed_version)
+    LATEST_VERSION=$(get_latest_version)
+
+    if [ "$CURRENT_VERSION" == "$LATEST_VERSION" ]; then
+        echo -e "${GREEN}GooseRelayVPN is already up to date ($CURRENT_VERSION).${NC}"
+        read -p "Do you want to force update anyway? (y/n): " choice
+        if [[ "$choice" != "y" ]]; then return; fi
+    else
+        echo -e "${YELLOW}A new version is available: $LATEST_VERSION (Current: $CURRENT_VERSION)${NC}"
+        read -p "Do you want to update? (y/n): " choice
+        if [[ "$choice" != "y" ]]; then return; fi
+    fi
+
+    PLATFORM=$(get_platform)
+    DOWNLOAD_URL="https://github.com/$REPO/releases/download/$LATEST_VERSION/GooseRelayVPN-server-$LATEST_VERSION-$PLATFORM.tar.gz"
+    
+    echo -e "${YELLOW}Downloading update $LATEST_VERSION...${NC}"
+    curl -L "$DOWNLOAD_URL" -o "/tmp/goose.tar.gz"
+    
+    # Stop service before updating
+    systemctl stop "$SERVICE_NAME" || true
+    
+    tar -xzf "/tmp/goose.tar.gz" -C "$INSTALL_DIR"
+    rm "/tmp/goose.tar.gz"
+    echo "$LATEST_VERSION" > "$INSTALL_DIR/.version"
+    
+    # Binary placement check again
+    if [ ! -f "$INSTALL_DIR/$BINARY_NAME" ]; then
+        FIND_BIN=$(find "$INSTALL_DIR" -name "$BINARY_NAME" -type f | head -n 1)
+        if [ -n "$FIND_BIN" ]; then
+            mv "$FIND_BIN" "$INSTALL_DIR/$BINARY_NAME"
+        fi
+    fi
+    chmod +x "$INSTALL_DIR/$BINARY_NAME"
+    
+    systemctl start "$SERVICE_NAME"
+    echo -e "${GREEN}Update complete!${NC}"
+}
+
+# Function to uninstall
+uninstall_server() {
+    read -p "Are you sure you want to uninstall GooseRelayVPN? (y/n): " choice
+    if [[ "$choice" == "y" ]]; then
+        echo -e "${YELLOW}Uninstalling...${NC}"
+        systemctl stop "$SERVICE_NAME" || true
+        systemctl disable "$SERVICE_NAME" || true
+        rm -f /etc/systemd/system/$SERVICE_NAME.service
+        systemctl daemon-reload
+        
+        rm -rf "$INSTALL_DIR"
+        echo -e "${GREEN}GooseRelayVPN uninstalled successfully.${NC}"
+    fi
+}
+
+# Function to reconfigure
+reconfigure_server() {
+    if [ ! -f "$INSTALL_DIR/$CONFIG_NAME" ]; then
+        echo -e "${RED}Configuration file not found.${NC}"
+        return
+    fi
+    
+    echo "1) Regenerate tunnel_key"
+    echo "2) Enable/Disable upstream_proxy"
+    read -p "Select an option: " choice
+    
+    case $choice in
+        1)
+            NEW_KEY=$(openssl rand -hex 32)
+            jq --arg key "$NEW_KEY" '.tunnel_key = $key' "$INSTALL_DIR/$CONFIG_NAME" > "$INSTALL_DIR/$CONFIG_NAME.tmp" && mv "$INSTALL_DIR/$CONFIG_NAME.tmp" "$INSTALL_DIR/$CONFIG_NAME"
+            echo -e "${GREEN}New tunnel_key generated: $NEW_KEY${NC}"
+            echo -e "${YELLOW}Remember to update your client config!${NC}"
+            systemctl restart "$SERVICE_NAME"
+            ;;
+        2)
+            HAS_PROXY=$(jq '.upstream_proxy' "$INSTALL_DIR/$CONFIG_NAME")
+            if [ "$HAS_PROXY" != "null" ]; then
+                echo "Upstream proxy is currently enabled ($HAS_PROXY)."
+                read -p "Disable it? (y/n): " dis
+                if [[ "$dis" == "y" ]]; then
+                    jq 'del(.upstream_proxy)' "$INSTALL_DIR/$CONFIG_NAME" > "$INSTALL_DIR/$CONFIG_NAME.tmp" && mv "$INSTALL_DIR/$CONFIG_NAME.tmp" "$INSTALL_DIR/$CONFIG_NAME"
+                    echo "Upstream proxy disabled."
+                fi
+            else
+                echo "Upstream proxy is currently disabled."
+                read -p "Enable it? (y/n): " en
+                if [[ "$en" == "y" ]]; then
+                    jq '.upstream_proxy = "socks5://127.0.0.1:40000"' "$INSTALL_DIR/$CONFIG_NAME" > "$INSTALL_DIR/$CONFIG_NAME.tmp" && mv "$INSTALL_DIR/$CONFIG_NAME.tmp" "$INSTALL_DIR/$CONFIG_NAME"
+                    echo "Upstream proxy enabled."
+                fi
+            fi
+            systemctl restart "$SERVICE_NAME"
+            ;;
+        *) echo "Invalid option";;
+    esac
+}
+
+# Main execution loop
+if [ "$#" -gt 0 ]; then
+    # Non-interactive mode if needed
+    case $1 in
+        install) install_server ;;
+        update) update_server ;;
+        uninstall) uninstall_server ;;
+        *) show_menu ;;
+    esac
+else
+    while true; do
+        show_menu
+        read -p "Enter choice [1-5]: " choice
+        case $choice in
+            1) install_server ;;
+            2) update_server ;;
+            3) uninstall_server ;;
+            4) reconfigure_server ;;
+            5) exit 0 ;;
+            *) echo -e "${RED}Invalid option${NC}" ;;
+        esac
+        echo ""
+    done
+fi

--- a/scripts/goose-server.sh
+++ b/scripts/goose-server.sh
@@ -58,6 +58,34 @@ get_latest_version() {
 
 # Function to get installed version
 get_installed_version() {
+    # 1. Try to get version from binary using -version flag
+    if [ -f "$INSTALL_DIR/$BINARY_NAME" ]; then
+        BIN_VERSION=$("$INSTALL_DIR/$BINARY_NAME" -version 2>/dev/null | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" || echo "")
+        if [ -n "$BIN_VERSION" ]; then
+            echo "$BIN_VERSION"
+            return
+        fi
+        
+        # 2. Try to get version from running server's /healthz
+        if [ -f "$INSTALL_DIR/$CONFIG_NAME" ]; then
+            PORT=$(jq -r '.server_port // 8443' "$INSTALL_DIR/$CONFIG_NAME" 2>/dev/null || echo "8443")
+            HEALTH_VERSION=$(curl -s --max-time 2 "http://127.0.0.1:$PORT/healthz" | jq -r '.version' 2>/dev/null || echo "")
+            if [[ "$HEALTH_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                echo "$HEALTH_VERSION"
+                return
+            fi
+        fi
+
+        # 3. Try to extract version string from binary using 'strings' (for older versions)
+        # We look for something like v1.5.0 at the end of a line
+        BIN_STRINGS_VERSION=$(strings "$INSTALL_DIR/$BINARY_NAME" | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" | head -n 1 || echo "")
+        if [ -n "$BIN_STRINGS_VERSION" ]; then
+            echo "$BIN_STRINGS_VERSION"
+            return
+        fi
+    fi
+    
+    # 4. Fallback to .version file
     if [ -f "$INSTALL_DIR/.version" ]; then
         cat "$INSTALL_DIR/.version"
     else


### PR DESCRIPTION
Implemented an easy-to-use server installer:

### Key Improvements:

1.  **Smart Discovery & Migration:**
    *   The script automatically detects if `goose-server` is already installed or running outside the standard `/root/goose` directory (by checking `pgrep`, `systemctl` unit paths, and common binary locations).
    *   If a non-standard installation is found, the script offers to migrate it to `/root/goose`, ensuring consistency for future updates.
    *   Migration includes stopping the old process, moving the `server_config.json`, installing the latest binary to `/root/goose`, and automatically updating any existing `systemd` service to point to the new paths.

2.  **Robust Version Tracking (Backward Compatible):**
    *   Implemented a 4-tier version detection strategy:
        1.  Binary `-version` flag (added in this update).
        2.  Querying the running server's `/healthz` API.
        3.  `strings` extraction from the binary (to find version patterns in legacy builds).
        4.  `.version` file fallback.
    *   This ensures the script accurately determines if an update is necessary, even for very old versions.

3.  **Refined Lifecycle Management:**
    *   The script handles the entire lifecycle: Install, Update, Uninstall, and Reconfigure.
    *   Uses `jq` for all JSON manipulations to prevent configuration corruption.
    *   Automates firewall configuration (`ufw`/`iptables`) and systemd persistence.

README needs to be updated to include this, allowing users to install the server with a single `curl | bash` command:
```bash
bash <(curl -Ls https://raw.githubusercontent.com/Kianmhz/GooseRelayVPN/main/scripts/goose-server.sh)
```

There may be room for improvement but this is a good start, tried making it as backwards-compatible as possible. This'll be a fool-proof way of installing the server relay, configuring and updating it.