### PR TITLE
Improve Apps Script relay and example configs

### DIFF
--- a/apps_script/Code.gs
+++ b/apps_script/Code.gs
@@ -5,27 +5,61 @@
 // and never sees plaintext or holds the key.
 //
 // Wire: client POSTs base64(encrypted batch). We forward the bytes verbatim
-// to RELAY_URL and return its response body verbatim.
+// to one of RELAY_URLS and return its response body verbatim.
 //
-// Replace RELAY_URL with your VPS address before deploying.
+// Replace RELAY_URLS with your VPS address(es) before deploying.
 
-const RELAY_URL = 'http://YOUR.VPS.IP:8443/tunnel';
+const RELAY_URLS = [
+  // Replace YOUR_SERVER_PORT with server_config.json's server_port.
+  // The dist/server_config.json used for the current test listens on 5443.
+  'http://YOUR.VPS.IP:YOUR_SERVER_PORT/tunnel',
+];
 const FORWARDER_VERSION = 1;
 const PROTOCOL_VERSION = 1;
+const ENABLE_INVOCATION_COUNTING = false;
+const GAS_RELAY_LOOP_RE = /^https?:\/\/script\.google\.com\/macros\//i;
 
 function doPost(e) {
-  bumpInvocationCount_();
+  for (let i = 0; i < RELAY_URLS.length; i++) {
+    if (GAS_RELAY_LOOP_RE.test(RELAY_URLS[i])) {
+      return ContentService
+        .createTextOutput('relay_loop_detected: RELAY_URLS must point to your VPS /tunnel endpoint, not Apps Script')
+        .setMimeType(ContentService.MimeType.TEXT);
+    }
+  }
+  if (ENABLE_INVOCATION_COUNTING) {
+    bumpInvocationCount_();
+  }
   const payload = (e && e.postData && e.postData.contents) || '';
-  const resp = UrlFetchApp.fetch(RELAY_URL, {
-    method: 'post',
-    contentType: 'text/plain',
-    payload: payload,
-    muteHttpExceptions: true,
-    followRedirects: false,
-    deadline: 30,  // seconds; long-poll window is kept at 8s for Apps Script stability
-  });
+  let lastText = '';
+  for (let i = 0; i < RELAY_URLS.length; i++) {
+    try {
+      const resp = UrlFetchApp.fetch(RELAY_URLS[i], {
+        method: 'post',
+        contentType: 'text/plain',
+        payload: payload,
+        muteHttpExceptions: true,
+        followRedirects: false,
+      });
+      const status = resp.getResponseCode();
+      const text = resp.getContentText();
+      lastText = text;
+      if (status === 200) {
+        return ContentService
+          .createTextOutput(text)
+          .setMimeType(ContentService.MimeType.TEXT);
+      }
+      lastText = JSON.stringify({
+        e: 'upstream_status',
+        status: status,
+        body: text.slice(0, 1024),
+      });
+    } catch (err) {
+      lastText = String(err);
+    }
+  }
   return ContentService
-    .createTextOutput(resp.getContentText())
+    .createTextOutput(lastText)
     .setMimeType(ContentService.MimeType.TEXT);
 }
 

--- a/apps_script/Code.gs
+++ b/apps_script/Code.gs
@@ -40,6 +40,7 @@ function doPost(e) {
         payload: payload,
         muteHttpExceptions: true,
         followRedirects: false,
+        deadline: 30,  // seconds; long-poll window is kept below this for Apps Script stability
       });
       const status = resp.getResponseCode();
       const text = resp.getContentText();

--- a/client_config.example.json
+++ b/client_config.example.json
@@ -4,20 +4,37 @@
   "socks_port": 1080,
   "google_host": "216.239.38.120",
   "sni": ["www.google.com", "mail.google.com", "accounts.google.com"],
+  "transport_mode": "auto",
+  "_comment_direct_stream": "Optional: only fill this if your VPS /stream endpoint is directly reachable. Leave empty for Apps Script-only mode.",
+  "direct_stream_urls": [],
+  "_comment_script_keys": "Add more entries here for extra deployments/accounts, e.g. {\"id\":\"AKfycb...\",\"account\":\"acct-b\"}. Deployments with the same account label share one Apps Script daily quota bucket.",
   "script_keys": [
-    {"id": "REPLACE_WITH_DEPLOYMENT_ID", "account": "acct-a"},
-    {"id": "OPTIONAL_SECOND_DEPLOYMENT_ID", "account": "acct-a"},
-    {"id": "OPTIONAL_THIRD_DEPLOYMENT_ID", "account": "acct-b"}
+    {"id": "REPLACE_WITH_DEPLOYMENT_ID", "account": "acct-a"}
   ],
-  "tunnel_key": "REPLACE_WITH_OUTPUT_OF_scripts_gen-key.sh",
+  "tunnel_key": "REPLACE_WITH_64_HEX_CHARACTER_RANDOM_KEY",
 
   "_comment_socks_auth": "Optional: require SOCKS5 username/password (RFC 1929). Both fields must be set together or both omitted.",
   "socks_user": "",
   "socks_pass": "",
 
+  "_comment_performance": "Optional speed profile: balanced, latency, or throughput. Explicit knobs below override the profile.",
+  "performance_mode": "latency",
+  "auto_tune": false,
+
   "_comment_coalesce": "Optional: adaptive uplink coalescing. Set coalesce_step_ms to a positive number to make a burst of TX operations wait a little for more operations before sending, which reduces Apps Script calls. A good starting range is 20-40 ms. Set it to 0 to turn coalescing off.",
   "coalesce_step_ms": 0,
 
   "_comment_idle_slots": "Optional download-throughput tuning. Default 1 (safe). Raise to 2 if each account has 2+ deployments — this may increase download throughput; leave at 1 for accounts with one deployment. Max 3. Omitting the field is equivalent to 1.",
-  "idle_slots_per_bucket": 1
+  "idle_slots_per_bucket": 1,
+
+  "_comment_advanced_performance": "Advanced: leave these defaults unless measuring. Lower poll_idle_sleep_ms can reduce latency; more workers/idle slots can increase throughput but raise request volume.",
+  "workers_per_endpoint": 4,
+  "poll_idle_sleep_ms": 5,
+  "endpoint_blacklist_base_ms": 3000,
+  "endpoint_blacklist_max_ms": 3600000,
+  "endpoint_outage_grace_ms": 60000,
+  "max_request_bytes_pre_encode": 8388608,
+  "stream_connect_timeout_ms": 5000,
+  "stream_ping_interval_ms": 20000,
+  "stream_reconnect_backoff_ms": 1000
 }

--- a/client_config.example.json
+++ b/client_config.example.json
@@ -4,9 +4,6 @@
   "socks_port": 1080,
   "google_host": "216.239.38.120",
   "sni": ["www.google.com", "mail.google.com", "accounts.google.com"],
-  "transport_mode": "auto",
-  "_comment_direct_stream": "Optional: only fill this if your VPS /stream endpoint is directly reachable. Leave empty for Apps Script-only mode.",
-  "direct_stream_urls": [],
   "_comment_script_keys": "Add more entries here for extra deployments/accounts, e.g. {\"id\":\"AKfycb...\",\"account\":\"acct-b\"}. Deployments with the same account label share one Apps Script daily quota bucket.",
   "script_keys": [
     {"id": "REPLACE_WITH_DEPLOYMENT_ID", "account": "acct-a"}
@@ -17,24 +14,9 @@
   "socks_user": "",
   "socks_pass": "",
 
-  "_comment_performance": "Optional speed profile: balanced, latency, or throughput. Explicit knobs below override the profile.",
-  "performance_mode": "latency",
-  "auto_tune": false,
-
   "_comment_coalesce": "Optional: adaptive uplink coalescing. Set coalesce_step_ms to a positive number to make a burst of TX operations wait a little for more operations before sending, which reduces Apps Script calls. A good starting range is 20-40 ms. Set it to 0 to turn coalescing off.",
   "coalesce_step_ms": 0,
 
   "_comment_idle_slots": "Optional download-throughput tuning. Default 1 (safe). Raise to 2 if each account has 2+ deployments — this may increase download throughput; leave at 1 for accounts with one deployment. Max 3. Omitting the field is equivalent to 1.",
-  "idle_slots_per_bucket": 1,
-
-  "_comment_advanced_performance": "Advanced: leave these defaults unless measuring. Lower poll_idle_sleep_ms can reduce latency; more workers/idle slots can increase throughput but raise request volume.",
-  "workers_per_endpoint": 4,
-  "poll_idle_sleep_ms": 5,
-  "endpoint_blacklist_base_ms": 3000,
-  "endpoint_blacklist_max_ms": 3600000,
-  "endpoint_outage_grace_ms": 60000,
-  "max_request_bytes_pre_encode": 8388608,
-  "stream_connect_timeout_ms": 5000,
-  "stream_ping_interval_ms": 20000,
-  "stream_reconnect_backoff_ms": 1000
+  "idle_slots_per_bucket": 1
 }

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -323,15 +323,15 @@ func LoadClient(path string) (*Client, error) {
 	relayURLs = dedupeStrings(relayURLs)
 
 	key := strings.TrimSpace(f.TunnelKey)
-	if key == "" || key == "REPLACE_WITH_OUTPUT_OF_scripts_gen-key.sh" {
-		return nil, fmt.Errorf("tunnel_key is empty or still the placeholder text in %s.\n  Fix: generate a key with 'bash scripts/gen-key.sh' and paste the 64-character output into the tunnel_key field. The same value must be in server_config.json", path)
+	if key == "" || key == "REPLACE_WITH_64_HEX_CHARACTER_RANDOM_KEY" {
+		return nil, fmt.Errorf("tunnel_key is empty or still the placeholder text in %s.\n  Fix: generate a key with 'openssl rand -hex 32' and paste the 64-character output into the tunnel_key field. The same value must be in server_config.json", path)
 	}
 	if len(key) != 64 {
-		return nil, fmt.Errorf("tunnel_key must be exactly 64 hex characters (got %d) in %s.\n  Fix: generate a fresh key with 'bash scripts/gen-key.sh' and paste the full output. Use the SAME value in client_config.json and server_config.json", len(key), path)
+		return nil, fmt.Errorf("tunnel_key must be exactly 64 hex characters (got %d) in %s.\n  Fix: generate a fresh key with 'openssl rand -hex 32' and paste the full output. Use the SAME value in client_config.json and server_config.json", len(key), path)
 	}
 	raw, err := hex.DecodeString(key)
 	if err != nil || len(raw) != 32 {
-		return nil, fmt.Errorf("tunnel_key in %s contains non-hex characters.\n  Valid characters are 0-9 and a-f. Generate a fresh key with 'bash scripts/gen-key.sh' and copy it carefully — no spaces, quotes, or extra newlines", path)
+		return nil, fmt.Errorf("tunnel_key in %s contains non-hex characters.\n  Valid characters are 0-9 and a-f. Generate a fresh key with 'openssl rand -hex 32' and copy it carefully — no spaces, quotes, or extra newlines", path)
 	}
 
 	useFronting := len(relayURLs) == 0

--- a/server_config.example.json
+++ b/server_config.example.json
@@ -2,6 +2,17 @@
   "server_host": "0.0.0.0",
   "server_port": 8443,
   "tunnel_key": "SAME_VALUE_AS_CLIENT_tunnel_key",
-  "upstream_proxy": "OPTIONAL_socks5://127.0.0.1:40000",
-  "debug_timing": false
+  "_comment_upstream_proxy": "Optional: set to socks5://127.0.0.1:40000 only after installing and connecting Cloudflare WARP or another local SOCKS5 proxy on the VPS. Leave empty otherwise.",
+  "upstream_proxy": "",
+  "debug_timing": false,
+  "auto_tune": false,
+  "performance_mode": "latency",
+  "active_drain_window_ms": 150,
+  "long_poll_window_ms": 6000,
+  "upstream_dial_timeout_ms": 8000,
+  "coalesce_window_ms": 0,
+  "coalesce_window_busy_ms": 0,
+  "max_sessions": 4096,
+  "max_request_body_bytes": 12582912,
+  "max_response_bytes_pre_encode": 23068672
 }

--- a/server_config.example.json
+++ b/server_config.example.json
@@ -4,15 +4,5 @@
   "tunnel_key": "SAME_VALUE_AS_CLIENT_tunnel_key",
   "_comment_upstream_proxy": "Optional: set to socks5://127.0.0.1:40000 only after installing and connecting Cloudflare WARP or another local SOCKS5 proxy on the VPS. Leave empty otherwise.",
   "upstream_proxy": "",
-  "debug_timing": false,
-  "auto_tune": false,
-  "performance_mode": "latency",
-  "active_drain_window_ms": 150,
-  "long_poll_window_ms": 6000,
-  "upstream_dial_timeout_ms": 8000,
-  "coalesce_window_ms": 0,
-  "coalesce_window_busy_ms": 0,
-  "max_sessions": 4096,
-  "max_request_body_bytes": 12582912,
-  "max_response_bytes_pre_encode": 23068672
+  "debug_timing": false
 }


### PR DESCRIPTION
## Summary

This PR improves the Apps Script forwarder and example configs without changing the tunnel protocol.

Changes:
- Adds `RELAY_URLS` support for multiple VPS tunnel endpoints.
- Adds a relay loop guard so Apps Script cannot accidentally relay to another Apps Script URL.
- Makes invocation counting optional to avoid a PropertiesService write on every tunnel request.
- Makes example configs safer to copy by avoiding invalid placeholder values.

## Verification

- `go test -count=1 ./...`
- `go vet ./...`

## Compatibility

The wire protocol is unchanged. Existing client/server deployments continue to work after redeploying `Code.gs`.
