### PR TITLE
Reduce frame marshaling allocations

### DIFF
--- a/internal/frame/bench_test.go
+++ b/internal/frame/bench_test.go
@@ -1,0 +1,57 @@
+package frame
+
+import (
+	"bytes"
+	"testing"
+)
+
+var (
+	benchFrameBytes  []byte
+	benchFrameResult *Frame
+)
+
+func BenchmarkFrameAppendMarshal_4KiB(b *testing.B) {
+	in := &Frame{
+		SessionID: sid(0x42),
+		Seq:       12345,
+		Flags:     FlagSYN,
+		Target:    "example.com:443",
+		Payload:   bytes.Repeat([]byte{'p'}, 4*1024),
+	}
+	dst := make([]byte, 0, in.EncodedLen())
+	b.SetBytes(int64(in.EncodedLen()))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		dst = dst[:0]
+		out, err := in.AppendMarshal(dst)
+		if err != nil {
+			b.Fatalf("append marshal: %v", err)
+		}
+		benchFrameBytes = out
+	}
+}
+
+func BenchmarkFrameUnmarshal_4KiB(b *testing.B) {
+	in := &Frame{
+		SessionID: sid(0x43),
+		Seq:       12345,
+		Flags:     FlagSYN,
+		Target:    "example.com:443",
+		Payload:   bytes.Repeat([]byte{'p'}, 4*1024),
+	}
+	raw, err := in.Marshal()
+	if err != nil {
+		b.Fatalf("marshal: %v", err)
+	}
+	b.SetBytes(int64(len(raw)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		out, _, err := Unmarshal(raw)
+		if err != nil {
+			b.Fatalf("unmarshal: %v", err)
+		}
+		benchFrameResult = out
+	}
+}

--- a/internal/frame/frame.go
+++ b/internal/frame/frame.go
@@ -34,6 +34,10 @@ type Frame struct {
 
 func (f *Frame) HasFlag(flag uint8) bool { return f.Flags&flag != 0 }
 
+func (f *Frame) EncodedLen() int {
+	return SessionIDLen + 8 + 1 + 1 + len(f.Target) + 4 + len(f.Payload)
+}
+
 // Marshal serializes the frame to a byte slice using the schema:
 //
 //	session_id  : 16 bytes
@@ -44,29 +48,40 @@ func (f *Frame) HasFlag(flag uint8) bool { return f.Flags&flag != 0 }
 //	payload_len : uint32 BE
 //	payload     : N bytes
 func (f *Frame) Marshal() ([]byte, error) {
+	return f.AppendMarshal(make([]byte, 0, f.EncodedLen()))
+}
+
+func (f *Frame) AppendMarshal(dst []byte) ([]byte, error) {
 	if len(f.Target) > maxTargetLen {
 		return nil, fmt.Errorf("target too long: %d > %d", len(f.Target), maxTargetLen)
 	}
 	if len(f.Payload) > maxPayloadSize {
 		return nil, fmt.Errorf("payload too large: %d", len(f.Payload))
 	}
-	size := SessionIDLen + 8 + 1 + 1 + len(f.Target) + 4 + len(f.Payload)
-	out := make([]byte, size)
+	size := f.EncodedLen()
+	base := len(dst)
+	if cap(dst)-base < size {
+		next := make([]byte, base, base+size)
+		copy(next, dst)
+		dst = next
+	}
+	dst = dst[:base+size]
+	out := dst[base:]
 	off := 0
-	copy(out[off:], f.SessionID[:])
+	copy(out[off:off+SessionIDLen], f.SessionID[:])
 	off += SessionIDLen
-	binary.BigEndian.PutUint64(out[off:], f.Seq)
+	binary.BigEndian.PutUint64(out[off:off+8], f.Seq)
 	off += 8
 	out[off] = f.Flags
 	off++
 	out[off] = uint8(len(f.Target))
 	off++
-	copy(out[off:], f.Target)
+	copy(out[off:off+len(f.Target)], f.Target)
 	off += len(f.Target)
-	binary.BigEndian.PutUint32(out[off:], uint32(len(f.Payload)))
+	binary.BigEndian.PutUint32(out[off:off+4], uint32(len(f.Payload)))
 	off += 4
-	copy(out[off:], f.Payload)
-	return out, nil
+	copy(out[off:off+len(f.Payload)], f.Payload)
+	return dst, nil
 }
 
 // Unmarshal parses a frame produced by Marshal. Returns the number of bytes

--- a/internal/frame/frame_test.go
+++ b/internal/frame/frame_test.go
@@ -107,6 +107,37 @@ func TestFrameRoundTrip_ACK(t *testing.T) {
 	}
 }
 
+func TestAppendMarshalMatchesMarshalAndReusesDestination(t *testing.T) {
+	in := &Frame{
+		SessionID: sid(0x33),
+		Seq:       123,
+		Flags:     FlagSYN,
+		Target:    "example.org:443",
+		Payload:   []byte("payload"),
+	}
+	prefix := []byte("prefix:")
+	dst := make([]byte, len(prefix), 128)
+	copy(dst, prefix)
+
+	got, err := in.AppendMarshal(dst)
+	if err != nil {
+		t.Fatalf("append marshal: %v", err)
+	}
+	wantFrame, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !bytes.Equal(got[:len(prefix)], prefix) {
+		t.Fatalf("prefix changed: %q", got[:len(prefix)])
+	}
+	if !bytes.Equal(got[len(prefix):], wantFrame) {
+		t.Fatalf("appended frame mismatch")
+	}
+	if cap(got) != cap(dst) {
+		t.Fatalf("AppendMarshal allocated despite sufficient destination capacity")
+	}
+}
+
 func TestUnmarshal_ShortHeader(t *testing.T) {
 	if _, _, err := Unmarshal([]byte{1, 2, 3}); err == nil {
 		t.Fatal("expected error on short header")


### PR DESCRIPTION
## Summary

This PR reduces frame marshaling allocations by adding an append-style encoder.

Changes:
- Adds `Frame.EncodedLen()`.
- Adds `Frame.AppendMarshal(dst)`.
- Makes `Marshal()` use `AppendMarshal()`.
- Adds tests verifying `AppendMarshal()` matches `Marshal()` and can reuse destination capacity.
- Adds small frame marshaling/unmarshaling benchmarks.

## Why

Batch encoding benefits from writing directly into pre-sized buffers. An append-style frame encoder avoids an intermediate allocation/copy per frame and makes future batch encoding optimizations simpler.

## Verification

- `go test -count=1 ./internal/frame`
- `go test -count=1 ./...`
- `go vet ./...`
