### PR TITLE
session: fix EnqueueInitialData reversing byte order on multi-call writers

### DIFF
--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -149,8 +149,22 @@ func (s *Session) EnqueueTx(data []byte) {
 	}
 }
 
-// EnqueueInitialData prepends data to the tx buffer if the SYN hasn't been sent
-// yet. Used by the connect_data optimization.
+// EnqueueInitialData appends data to the tx buffer while synNeeded is still
+// true, so the first DrainTx call bundles it into the SYN frame's payload
+// (the connect_data optimization — saves one round-trip on every TLS
+// handshake and HTTP request).
+//
+// Previously this prepended, on the assumption it'd be called once before
+// any other write. But the SOCKS5 adapter calls it on every Write, and the
+// local write loop is frequently faster than poll workers — multiple calls
+// land before the SYN drains, and prepending REVERSES byte order. For a
+// payload whose first bytes carry framing/length (a TLS record header, an
+// HTTP request line, the bench harness's 8-byte size prefix), reordering
+// silently corrupts the upstream stream. The bug also rendered every
+// upload-throughput benchmark we have meaningless: with a size-prefixed
+// payload of zeros, the upstream parsed a body chunk's leading zeros as
+// "expect 0 bytes" and ACKed immediately, making upload look ~5× faster
+// than it actually was.
 func (s *Session) EnqueueInitialData(data []byte) {
 	s.mu.Lock()
 	if !s.synNeeded {
@@ -159,8 +173,7 @@ func (s *Session) EnqueueInitialData(data []byte) {
 		s.EnqueueTx(data)
 		return
 	}
-	// Prepend to txBuf so it's picked up by the first DrainTx call.
-	s.txBuf = append(data, s.txBuf...)
+	s.txBuf = append(s.txBuf, data...)
 	if s.firstQueuedAt.IsZero() {
 		s.firstQueuedAt = time.Now()
 	}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -263,3 +263,37 @@ func TestRollbackDrain_PreservesConcurrentEnqueue(t *testing.T) {
 		t.Fatalf("merged payload: got %q want %q", got, want)
 	}
 }
+
+// TestEnqueueInitialData_PreservesOrderAcrossMultipleCalls catches the regression
+// where EnqueueInitialData prepended (instead of appending) while synNeeded was
+// true. The SOCKS5 adapter calls this on every Write, and a fast local writer
+// can fit many calls between session creation and the SYN drain. Prepend
+// reversed byte order on the wire; for any protocol whose first bytes carry
+// framing (TLS records, HTTP request lines, length prefixes), the upstream
+// would either error or parse garbage. The bench harness's sized upload sink
+// silently masked this by ACKing on a 0-length body when the body's leading
+// zeros were read as the size header, producing wildly optimistic upload
+// throughput measurements.
+func TestEnqueueInitialData_PreservesOrderAcrossMultipleCalls(t *testing.T) {
+	s := New(sid(10), "example.com:443", true)
+
+	// Simulate a SOCKS5 writer calling Write multiple times before the
+	// carrier's poll worker drains the SYN: a length-prefix header followed
+	// by body chunks. The order matters; reverse order would put the body
+	// before the header and the upstream would misparse.
+	s.EnqueueInitialData([]byte("HDR_"))
+	s.EnqueueInitialData([]byte("body_chunk_1_"))
+	s.EnqueueInitialData([]byte("body_chunk_2"))
+
+	frames := s.DrainTx(64 * 1024)
+	if len(frames) != 1 {
+		t.Fatalf("want 1 bundled frame, got %d", len(frames))
+	}
+	if !frames[0].HasFlag(frame.FlagSYN) {
+		t.Fatal("first frame missing SYN")
+	}
+	want := []byte("HDR_body_chunk_1_body_chunk_2")
+	if !bytes.Equal(frames[0].Payload, want) {
+		t.Fatalf("payload ordering corrupt: got %q want %q", frames[0].Payload, want)
+	}
+}


### PR DESCRIPTION
## Summary

\`EnqueueInitialData\` was implemented to **prepend** to the tx buffer while \`synNeeded\` was true. The assumption was \"called once, before the SYN drains.\" But the SOCKS5 adapter calls it on **every** \`Write\`, and a fast local writer can fit many calls before a poll worker drains the SYN. Each prepend pushed new bytes in front of the existing buffer, so the on-wire byte order ended up **reversed**.

For any protocol whose leading bytes carry framing — a TLS record header, an HTTP request line, a length prefix — the upstream parses garbage or rejects the stream. The bug has existed since the connect_data optimization landed in v1.4.

## Specific consequence: every upload-throughput bench result has been wrong

The bench's \`sized\` sink ([\`bench/sink/main.go\`](bench/sink/main.go)) reads the first 8 bytes as a size header. With prepend, those 8 bytes came from the **last** chunk written before the SYN drained — usually a body chunk full of zeros, decoded as \`size=0\`. The sink ACKed instantly without reading the body, and the harness measured the time-to-instant-ACK as upload throughput.

That made v1.5 look like 22 MB/s when actual upload is ~5 MB/s. The whole \"v1.5→v1.6 upload regression\" narrative behind [#143](https://github.com/Kianmhz/GooseRelayVPN/pull/143) was a bench artifact. With the prepend fixed and \`workersPerEndpoint\` tested at 3, 4, and 5:

| `workersPerEndpoint` | 8 MB single-session upload | 8 MB 4-session upload | sessions_per_sec |
|---|---|---|---|
| 3 (current main) | 4.49 MB/s | ~17 MB/s | 4.5/s |
| 4 (pre-#143) | 4.49 MB/s | ~17 MB/s | 50/s |
| 5 | 4.49 MB/s | 17.8 MB/s | 90/s |

The per-session ceiling is `maxDrainFramesPerSession × MaxFramePayload / ActiveDrainWindow` ≈ 5.85 MB/s. Worker count doesn't change it. 4 concurrent sessions get 4 × the per-session number, as you'd expect.

## What does NOT change

- The carrier protocol is unchanged. This is purely a local-buffer correctness fix.
- Existing single-write callers (the common case for new connections) are unaffected: with one Write before drain, append vs prepend gives the same result.
- The connect_data optimization still works — data still bundles into the SYN frame.

## What DOES change for real users

- Any application that writes a length-prefixed or framed payload immediately after connecting was hitting silent corruption on the first message. TLS handshakes were OK because ClientHello is usually one Write that fits in the SYN frame. HTTP/1.1 was OK because the first Write usually fits the request line + headers. But anything that issued the request line and the body as separate Writes within microseconds of \`Dial()\` could see the request body arrive before the request line on the upstream.
- This may have caused obscure first-request failures users couldn't reproduce.

## What's next (separate work)

This fix means [#143](https://github.com/Kianmhz/GooseRelayVPN/pull/143)'s premise (v1.5→v1.6 upload regression caused by `workersPerEndpoint=4`) was wrong — the upload numbers were always bench artifacts. A follow-up should:

1. Revert [#143](https://github.com/Kianmhz/GooseRelayVPN/pull/143) (back to `workersPerEndpoint=4`) — no upload regression to worry about, get back the v1.6 session-open speedup.
2. Reconsider the spike in [#146](https://github.com/Kianmhz/GooseRelayVPN/pull/146) on its real merits (unlabeled-multi-endpoint configs went from v1.5's 15 workers to v1.6's 4 — that part of the regression is real).
3. To genuinely improve per-session upload throughput beyond ~6 MB/s, the per-session in-flight lock and the 350 ms `ActiveDrainWindow` need design work — out of scope here.

## Verification

- `go test -count=1 -timeout 90s ./...` — all green; new test catches the bug.
- `./bench/bench.sh --baseline v1.6.0 --scenario throughput_up_8MB_1session` — 3 consecutive runs all report 4.49 MB/s (vs the previous lying 22.3 MB/s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)